### PR TITLE
Propagate exceptions for bootstrapper NativeFunction

### DIFF
--- a/src/agent.ts
+++ b/src/agent.ts
@@ -3,7 +3,7 @@ rpc.exports = {
         const bootstrapperModule = Module.load(bootstrapper);
 
         const functionPointer = bootstrapperModule.getExportByName("bootstrapper_load_assembly");
-        const bootstrapper_load_assembly = new NativeFunction(functionPointer, "uint32", ["pointer", "pointer", "pointer", "pointer"]);
+        const bootstrapper_load_assembly = new NativeFunction(functionPointer, "uint32", ["pointer", "pointer", "pointer", "pointer"], { exceptions: "propagate" });
 
         const allocUtfString = Process.platform === "windows" ? Memory.allocUtf16String : Memory.allocUtf8String;
         return bootstrapper_load_assembly(


### PR DESCRIPTION
Add `exceptions: "propagate"` (default is `steal`) to NativeFunction call for bootstrapper to resolve `new Harmony` call exceptions on native call

Currently, the demo `_run.bat` fails to finish hook initialization.
It starts here https://github.com/StackOverflowExcept1on/net-core-injector/blob/d856191081812dbbfdc8d16777eb7ee853302ebe/Bootstrapper/src/library.cpp#L110 
And then fails here https://github.com/StackOverflowExcept1on/net-core-injector/blob/d856191081812dbbfdc8d16777eb7ee853302ebe/RuntimePatcher/RuntimePatcher/Lib.cs#L16
It seems to me `new Harmony` starts to load something which throws benign exception (tries to resolve/load `0Harmony.dll` or does reflection?) which frida `steal` by default.
See [nativefunction](https://frida.re/docs/javascript-api/#nativefunction)

`exceptions: "propagate"` helps to let the app RuntimePatcher to properly deal with Harmony code injection initialization.

Before:
<img width="1382" height="854" alt="image" src="https://github.com/user-attachments/assets/a1141119-d132-483b-9f5e-c8d363e1fe81" />

After:
<img width="1349" height="857" alt="image" src="https://github.com/user-attachments/assets/e07d2fdb-490d-4609-a164-c78e62d8fa34" />
